### PR TITLE
Bugfix/test run fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,60 @@
-# 5K Workout Companion
+# 5K Training Plan
+
 A simple and intuitive web app to help you follow the [Couch to 5K training plan](https://c25k.com/c25k_plan/). Designed to be used during your workouts, it displays the current activity (such as "Walk" or "Jog") and the duration, keeping you motivated and on track.
 
-### Features
-* Displays current workout activity (ex: Walk, Jog)
-* Shows the remaining duration for each activity
-* Easy to use during exercise sessions
-* Built with HTML, CSS, and JavaScript
+## 🚀 Features
 
-### How to Use
-1. Download or clone this repository.
-2. Open `index.html` in your web browser.
+- Select training week (1-9) and workout (1-3)
+- Adjustable Warm Up and Cool Down durations
+- Guided workout flow with:
+  - Clear action prompts (walk, jog, warm up, cool down)
+  - Audio beep cues for transitions
+- Animated countdown ring showing remaining duration for each activity
+- Automatic progression through all workout intervals
+- Clean, distraction-free interface
+- Easy to use during exercise sessions
+
+## 🧠 How It Works
+
+1. Adjust settings (optional):
+   - Week (1-9)
+   - Workout (1-3)
+   - Warm Up Duration
+   - Cool Down Duration
+2. Press "Start" button
 3. Start your workout and follow the on-screen prompts for activity and duration.
 
-### Customization
-You can customize the workout schedule by editing the JavaScript code to change activities, durations, or add new features.
+## ▶️ Getting Started
 
-### Technologies Used
-* HTML
-* CSS
-* JavaScript
+### Prerequisites
 
-### License
+You'll need a local development server to run the app
+
+### Run Locally
+
+1.  Clone the repository
+
+        git clone https://github.com/andreaanger/5k-training-plan.git
+
+2.  Navigate into the project folder
+
+        cd 5k-training-plan
+
+3.  Start a local server (example: VS Code Live Server)
+4.  Open the `index.html` file in your browser
+
+## 🛠️ Technologies Used
+
+- HTML
+- CSS
+- JavaScript
+
+## ⚠️ Limitations
+
+- No pause/resume functionality
+- No persistent settings (no localStorage)
+- Requires a local server (does not run directly from file system in some browsers)
+
+## 📄 License
+
 This project is open source. Feel free to use and modify it as needed!
-

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ You'll need a local development server to run the app
 - HTML
 - CSS
 - JavaScript
+- GitHub Copilot
+
+## 🤖 AI-Assisted Development
+
+This project was built with the assistance of AI. GitHub Copilot was used to accelerate:
+
+- **Development:** boilerplate, debugging, and logic implementation.
+- **Project Management:** generation of GitHub Issues.
+- **Quality Assurance:** PR reviews for code consistency and bug detection.
+
+_Note: While AI helped streamline the creation of issues and code, every line has been human-verified to ensure it meets the project's quality standards_
 
 ## ⚠️ Limitations
 

--- a/index.html
+++ b/index.html
@@ -37,29 +37,27 @@
           <tr>
             <td><label class="settings-duration-title" for="settings-warmup-slider">WARM UP</label></td>
             <td>
+              <p class="settings-duration-display" id="settings-warmup-duration-label">5:00</p>
+            </td>
+          </tr>
+          <tr>
+            <td colspan="2">
               <div class="slidecontainer">
                 <input type="range" min="0" max="40" value="20" class="settings-duration-slider" id="settings-warmup-slider" />
               </div>
             </td>
           </tr>
           <tr>
-            <td></td>
+            <td><label class="settings-duration-title" for="settings-cooldown-slider">COOL DOWN</label></td>
             <td>
-              <p class="settings-duration-display" id="settings-warmup-duration-label">5:00</p>
+              <p class="settings-duration-display" id="settings-cooldown-duration-label">5:00</p>
             </td>
           </tr>
           <tr>
-            <td><label class="settings-duration-title" for="settings-cooldown-slider">COOL DOWN</label></td>
-            <td>
+            <td colspan="2">
               <div class="slidecontainer">
                 <input type="range" min="0" max="40" value="20" class="settings-duration-slider" id="settings-cooldown-slider" />
               </div>
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <td>
-              <p class="settings-duration-display" id="settings-cooldown-duration-label">5:00</p>
             </td>
           </tr>
         </table>

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -45,6 +45,9 @@ document.querySelectorAll(".nav-btn").forEach((button) => {
 export function navigateTo(screenId) {
   const container = document.getElementById("app-container");
   container.setAttribute("data-current-screen", screenId);
+  if (screenId === "settings") {
+    syncSettingsUIWithCurrentWorkout();
+  }
 }
 
 /*** HOME - WORKOUT NUMBER SELECTION ***/
@@ -75,6 +78,20 @@ document.getElementById("home-workout-view-workout-btn").addEventListener("click
 document.getElementById("home-start-btn").addEventListener("click", function () {
   startWorkoutPlan(workoutSession);
 });
+
+/*** SETTINGS - DEFAULT VALUES ON NAV TO ***/
+function syncSettingsUIWithCurrentWorkout() {
+  document.getElementById("settings-warmup-slider").value = workoutSession.warmUpDuration / 15;
+  document.getElementById("settings-cooldown-slider").value = workoutSession.coolDownDuration / 15;
+  document.getElementById("settings-warmup-duration-label").textContent = convertSecondsToMinutes(workoutSession.warmUpDuration);
+  document.getElementById("settings-cooldown-duration-label").textContent = convertSecondsToMinutes(workoutSession.coolDownDuration);
+  document.querySelectorAll(".settings-week-num-btn").forEach((button) => {
+    button.classList.remove("week-num-selected");
+    if (parseInt(button.textContent) === workoutSession.weekNumber) {
+      button.classList.add("week-num-selected");
+    }
+  });
+}
 
 /*** SETTINGS - DURATION SLIDERS ***/
 document.querySelectorAll(".settings-duration-slider").forEach((slider) => {

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -2,6 +2,7 @@ import WorkoutSession from "./workoutPlan.js";
 const TESTING_MODE = false; // set to true to run test workout plan
 let workoutSession;
 const actionTransitionBeep = new Audio("audio/195927__oneiroidstate__beep-1000-hz-length-of-1-frame-to-24-framesec-code-film.wav");
+let targetTime;
 
 function configureAudioForMixing() {
   // Safari/iOS can mix app audio with other audio when using an "ambient" session.
@@ -192,6 +193,8 @@ async function startWorkoutPlan(workout) {
   console.log(
     `Starting workout:\n WEEK: ${workout.weekNumber}\n Number: ${workout.workoutNumber}\n Warmup: ${convertSecondsToMinutes(workout.warmUpDuration)}\n Cooldown: ${convertSecondsToMinutes(workout.coolDownDuration)}`,
   );
+  // save the current time at start of the workout session to calculate accurate end times for each step, rather than relying on setTimeout which can drift over time
+  targetTime = Date.now();
   // Run each step in order; wait for the current timer to finish before starting the next.
   for (const step of workout.workoutSession) {
     displayCurrentActionFullScreen(step.name);
@@ -202,7 +205,8 @@ async function startWorkoutPlan(workout) {
 
 function startWorkoutTimerCountdown(actionName, duration) {
   return new Promise((resolve) => {
-    const targetTime = Date.now() + duration * 1000;
+    targetTime = targetTime + duration * 1000;
+    // Timer UI
     const timerCountdownElement = document.getElementById("workout-timer");
     const timerRingProgressElement = document.getElementById("workout-timer-ring-progress");
     const ringRadius = 52;
@@ -215,6 +219,7 @@ function startWorkoutTimerCountdown(actionName, duration) {
     timerRingProgressElement.style.strokeDasharray = `${ringCircumference}`;
     timerRingProgressElement.style.strokeDashoffset = "0";
 
+    // Timer logic
     let completed = false;
     let countdownInterval;
     let completionTimeout;

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -2,7 +2,6 @@ import WorkoutSession from "./workoutPlan.js";
 const TESTING_MODE = false; // set to true to run test workout plan
 let workoutSession;
 const actionTransitionBeep = new Audio("audio/195927__oneiroidstate__beep-1000-hz-length-of-1-frame-to-24-framesec-code-film.wav");
-let targetTime;
 
 function configureAudioForMixing() {
   // Safari/iOS can mix app audio with other audio when using an "ambient" session.
@@ -90,6 +89,7 @@ document.getElementById("home-workout-view-workout-btn").addEventListener("click
 
 /*** HOME - START ***/
 document.getElementById("home-start-btn").addEventListener("click", function () {
+  this.disabled = true;
   startWorkoutPlan(workoutSession);
 });
 
@@ -199,18 +199,18 @@ async function startWorkoutPlan(workout) {
     `Starting workout:\n WEEK: ${workout.weekNumber}\n Number: ${workout.workoutNumber}\n Warmup: ${convertSecondsToMinutes(workout.warmUpDuration)}\n Cooldown: ${convertSecondsToMinutes(workout.coolDownDuration)}`,
   );
   // save the current time at start of the workout session to calculate accurate end times for each step, rather than relying on setTimeout which can drift over time
-  targetTime = Date.now();
+  let targetTime = Date.now();
   // Run each step in order; wait for the current timer to finish before starting the next.
   for (const step of workout.workoutSession) {
     displayCurrentActionFullScreen(step.name);
-    await startWorkoutTimerCountdown(step.name, step.duration);
+    targetTime = targetTime + step.duration * 1000;
+    await startWorkoutTimerCountdown(step.name, step.duration, targetTime);
   }
   workoutComplete();
 }
 
-function startWorkoutTimerCountdown(actionName, duration) {
+function startWorkoutTimerCountdown(actionName, duration, targetTime) {
   return new Promise((resolve) => {
-    targetTime = targetTime + duration * 1000;
     // Timer UI
     const timerCountdownElement = document.getElementById("workout-timer");
     const timerRingProgressElement = document.getElementById("workout-timer-ring-progress");

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -3,7 +3,20 @@ const TESTING_MODE = false; // set to true to run test workout plan
 let workoutSession;
 const actionTransitionBeep = new Audio("audio/195927__oneiroidstate__beep-1000-hz-length-of-1-frame-to-24-framesec-code-film.wav");
 
+function configureAudioForMixing() {
+  // Safari/iOS can mix app audio with other audio when using an "ambient" session.
+  if ("audioSession" in navigator && navigator.audioSession) {
+    try {
+      navigator.audioSession.type = "ambient";
+    } catch (error) {
+      console.warn("Audio session type could not be set:", error);
+    }
+  }
+}
+
 function main() {
+  configureAudioForMixing();
+
   if (TESTING_MODE) {
     console.log("Setting up TEST workout plan...");
     setupTestWorkout();
@@ -243,6 +256,8 @@ function workoutComplete() {
 
 function playActionTransitionBeep() {
   try {
+    configureAudioForMixing();
+    actionTransitionBeep.currentTime = 0;
     const playResult = actionTransitionBeep.play();
     if (playResult && typeof playResult.then === "function") {
       playResult.catch((error) => {

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -177,12 +177,17 @@ function getCurrentPlanWeekNumber() {
     In a site with multiple users this would be determined by 
     the current users start date
   */
-  const week1Start = new Date(2026, 1, 23); // months are 0-indexed (ex: Feb = 1)
+  const week1Start = new Date(2026, 2, 9); // months are 0-indexed (ex: Feb = 1)
   const currentDate = new Date();
   // Difference in days between currentDate and week1Start
   const diffInMs = currentDate - week1Start;
   const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
-  return Math.floor(diffInDays / 7) + 1;
+  let weekNumber = Math.floor(diffInDays / 7) + 1;
+  if (weekNumber > 9) {
+    console.log("Week number is out of plan range, defaulting to week 1");
+    weekNumber = 1;
+  }
+  return weekNumber;
 }
 
 /**************************


### PR DESCRIPTION
_NOTE: This app has not been fully tested! There have been a few adjustments needed after some light user testing and this PR addresses them._

Issues:
* README was outdated information
* Workout time drift was still occurring (after a few actions the app falls a few seconds behind a physical clock)
* If user was playing audio while using the workout app, when the action transition sound was played it would stop the music and the user would have to manually resume playback of music.
* Settings screen - Warm Up and Cool Down duration label is covered by user thumb when adjusting values on mobile
* Settings screen - Warm Up and Cool Down duration labels and slider values persist when exiting settings screen, without saving changes. 

Changes:
* README updated to reflect current app features, etc
* App now stores the workout start time and calculates the action timers from that time
* Transition sound plays at the same time as user music, etc
* Settings screen - Warm Up and Cool Down duration labels moved to be above the sliders
* Settings screen - Warm Up and Cool Down duration labels and slider values are pulled from workout session each time settings screen is displayed